### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -5,6 +5,9 @@ jobs:
   linter_name:
     name: runner / black
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Check files using the black formatter


### PR DESCRIPTION
Potential fix for [https://github.com/Alcheri/Wikipedia/security/code-scanning/2](https://github.com/Alcheri/Wikipedia/security/code-scanning/2)

In general, this problem is fixed by adding an explicit `permissions:` block either at the workflow level (top-level, affecting all jobs) or at the job level, and granting only the scopes that are strictly required. For this workflow, most steps only need read access to repository contents, but the `create-pull-request` step needs to push commits and open/update PRs. That translates to `contents: write` and `pull-requests: write` for the job (or workflow).

The best minimal fix without changing behavior is to add a `permissions:` block under the `linter_name` job in `.github/workflows/black.yml`. This keeps the permissions scoped to this job only and clearly documents that it needs write access to contents and pull requests. We do not change any steps or action usages, only the job configuration. Concretely, insert:

```yaml
    permissions:
      contents: write
      pull-requests: write
```

between `runs-on: ubuntu-latest` (line 7) and `steps:` (line 8). No imports or additional definitions are required; this is purely a YAML configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
